### PR TITLE
Upgrade to dns-parser master

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -104,7 +104,9 @@ impl InterfaceDiscovery
     /// Send multicasted DNS queries.
     fn send(&mut self, service_name: &str) -> Result<(), Error> {
         let mut builder = dns::Builder::new_query(0, false);
+        let prefer_unicast = false;
         builder.add_question(service_name,
+                             prefer_unicast,
                              dns::QueryType::PTR,
                              dns::QueryClass::IN);
         let packet_data = builder.build().unwrap();


### PR DESCRIPTION
This upgrades to the master branch of `dns-parser`. As of yet the changes on there are not released.

My personal motivation for doing this is because of https://github.com/tailhook/dns-parser/issues/29. For getting the name of a Chromecast in a robust way, TXT records should not be concatenated. That was fixed upstream but not released yet.

I tried to keep the changes to the API minimal. On the other hand, it might good idea to expose the `dns-parser` types directly without wrapping them. What are your thoughts on that?