### PR TITLE
add methods for resolving known hosts instead of discovering all hosts

### DIFF
--- a/examples/chromecast_discovery.rs
+++ b/examples/chromecast_discovery.rs
@@ -1,6 +1,6 @@
 use futures_util::{pin_mut, stream::StreamExt};
-use mdns::{Error, Record, RecordKind};
-use std::{net::IpAddr, time::Duration};
+use mdns::Error;
+use std::time::Duration;
 
 const SERVICE_NAME: &'static str = "_googlecast._tcp.local";
 
@@ -9,21 +9,14 @@ async fn main() -> Result<(), Error> {
     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();
     pin_mut!(stream);
     while let Some(Ok(response)) = stream.next().await {
-        let addr = response.records().filter_map(self::to_ip_addr).next();
+        let addr = response.socket_address();
+        let host = response.hostname();
 
-        if let Some(addr) = addr {
-            println!("found cast device at {}", addr);
+        if let (Some(host), Some(addr)) = (host, addr) {
+            println!("found cast device {} at {}", host, addr);
         } else {
             println!("cast device does not advertise address");
         }
     }
     Ok(())
-}
-
-fn to_ip_addr(record: &Record) -> Option<IpAddr> {
-    match record.kind {
-        RecordKind::A(addr) => Some(addr.into()),
-        RecordKind::AAAA(addr) => Some(addr.into()),
-        _ => None,
-    }
 }

--- a/examples/http_discovery.rs
+++ b/examples/http_discovery.rs
@@ -1,6 +1,6 @@
 use futures_util::{pin_mut, stream::StreamExt};
-use mdns::{Error, Record, RecordKind};
-use std::{net::IpAddr, time::Duration};
+use mdns::Error;
+use std::time::Duration;
 
 const SERVICE_NAME: &'static str = "_http._tcp.local";
 
@@ -9,7 +9,7 @@ async fn main() -> Result<(), Error> {
     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();
     pin_mut!(stream);
     while let Some(Ok(response)) = stream.next().await {
-        let addr = response.records().filter_map(self::to_ip_addr).next();
+        let addr = response.ip_addr();
 
         if let Some(addr) = addr {
             println!("found cast device at {}", addr);
@@ -18,12 +18,4 @@ async fn main() -> Result<(), Error> {
         }
     }
     Ok(())
-}
-
-fn to_ip_addr(record: &Record) -> Option<IpAddr> {
-    match record.kind {
-        RecordKind::A(addr) => Some(addr.into()),
-        RecordKind::AAAA(addr) => Some(addr.into()),
-        _ => None,
-    }
 }

--- a/examples/resolve_hosts.rs
+++ b/examples/resolve_hosts.rs
@@ -1,0 +1,18 @@
+use mdns::Error;
+use std::time::Duration;
+
+const SERVICE_NAME: &'static str = "_http._tcp.local";
+const HOSTS: [&'static str; 2] = ["server1._http._tcp.local", "server2._http._tcp.local"];
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    let responses = mdns::resolve::multiple(SERVICE_NAME, &HOSTS, Duration::from_secs(15)).await?;
+
+    for response in responses {
+        if let (Some(host), Some(ip)) = (response.hostname(), response.ip_addr()) {
+            println!("found host {} at {}", host, ip)
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub use self::errors::Error;
 pub use self::response::{Record, RecordKind, Response};
 
 pub mod discover;
+pub mod resolve;
 
 mod errors;
 mod mdns;

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,0 +1,89 @@
+//! Utilities for resolving a devices on the LAN.
+//!
+//! Examples
+//!
+//! ```rust,no_run
+//! use mdns::Error;
+//! use std::time::Duration;
+//!
+//! const SERVICE_NAME: &'static str = "_googlecast._tcp.local";
+//! const HOST: &'static str = "mycast._googlecast._tcp.local";
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Error> {
+//!     if let Some(response) = mdns::resolve::one(SERVICE_NAME, HOST, Duration::from_secs(15)).await? {
+//!         println!("{:?}", response);
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+
+use crate::{Error, Response};
+use futures_util::pin_mut;
+use futures_util::StreamExt;
+use std::time::Duration;
+
+/// Resolve a single device by hostname
+pub async fn one<S>(
+    service_name: &str,
+    host_name: S,
+    timeout: Duration,
+) -> Result<Option<Response>, Error>
+where
+    S: AsRef<str>,
+{
+    // by setting the query interval higher than the timeout we ensure we only make one query
+    let stream = crate::discover::all(service_name, timeout * 2)?.listen();
+    pin_mut!(stream);
+
+    let process = async {
+        while let Some(Ok(response)) = stream.next().await {
+            match response.hostname() {
+                Some(found_host) if found_host == host_name.as_ref() => return Some(response),
+                _ => {}
+            }
+        }
+
+        None
+    };
+
+    Ok(match tokio::time::timeout(timeout, process).await {
+        Ok(result) => result,
+        Err(_) => None,
+    })
+}
+
+/// Resolve multiple devices by hostname
+pub async fn multiple<S>(
+    service_name: &str,
+    host_names: &[S],
+    timeout: Duration,
+) -> Result<Vec<Response>, Error>
+where
+    S: AsRef<str>,
+{
+    // by setting the query interval higher than the timeout we ensure we only make one query
+    let stream = crate::discover::all(service_name, timeout * 2)?.listen();
+    pin_mut!(stream);
+
+    let mut found = Vec::new();
+
+    let process = async {
+        while let Some(Ok(response)) = stream.next().await {
+            match response.hostname() {
+                Some(found_host) if host_names.iter().any(|s| s.as_ref() == found_host) => {
+                    found.push(response);
+
+                    if found.len() == host_names.len() {
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+    };
+
+    let _ = tokio::time::timeout(timeout, process).await;
+    Ok(found)
+}


### PR DESCRIPTION
Build on top of #18

Saves people from having to deal with the  stream and timeout logic in cases where you only want to resolve some known devices.