### PR TITLE
use async-std instead of tokio. Bump version 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dylan McKay <me@dylanmckay.io>"]
 edition = "2018"
 
@@ -24,7 +24,4 @@ err-derive = "0.2.1"
 futures-core = "0.3.1"
 futures-util = "0.3.1"
 async-stream = "0.2.0"
-tokio = { version = "0.2.4", features = ["time", "udp", "stream"] }
-
-[dev-dependencies]
-tokio = { version = "0.2.4", features = ["macros", "rt-core"] }
+async-std = { version = "1.6.2", features = ["unstable"] }

--- a/src/discover.rs
+++ b/src/discover.rs
@@ -26,10 +26,7 @@ use crate::{mDNSListener, Error, Response};
 
 use std::time::Duration;
 
-use tokio::time;
-
 use crate::mdns::{mDNSSender, mdns_interface};
-use async_stream::stream;
 use futures_core::Stream;
 use futures_util::{future::ready, stream::select, StreamExt};
 use std::net::Ipv4Addr;
@@ -49,7 +46,7 @@ pub struct Discovery {
     ignore_empty: bool,
 
     /// The interval we should send mDNS queries.
-    send_request_interval: time::Interval,
+    send_request_interval: Duration,
 }
 
 /// Gets an iterator over all responses for a given service on all interfaces.
@@ -77,7 +74,7 @@ where
         mdns_sender,
         mdns_listener,
         ignore_empty: true,
-        send_request_interval: time::interval(mdns_query_interval),
+        send_request_interval: mdns_query_interval,
     })
 }
 
@@ -90,27 +87,21 @@ impl Discovery {
         self
     }
 
-    fn interval_send(
-        mut interval: time::Interval,
-        mut sender: mDNSSender,
-    ) -> impl Stream<Item = ()> {
-        stream! {
-            loop {
-                interval.tick().await;
-                let _ = sender.send_request().await;
-
-                yield;
-            }
-        }
-    }
-
     pub fn listen(self) -> impl Stream<Item = Result<Response, Error>> {
         let ignore_empty = self.ignore_empty;
         let service_name = self.service_name;
         let response_stream = self.mdns_listener.listen().map(StreamResult::Response);
+        let sender = self.mdns_sender.clone();
 
-        let interval_stream = Self::interval_send(self.send_request_interval, self.mdns_sender)
-            .map(|_| StreamResult::Interval);
+        let interval_stream = async_std::stream::interval(self.send_request_interval)
+            // I don't like the double clone, I can't find a prettier way to do this
+            .map(move |_| {
+                let mut sender = sender.clone();
+                async_std::task::spawn(async move {
+                    let _ = sender.send_request().await;
+                });
+                StreamResult::Interval
+            });
 
         let stream = select(response_stream, interval_stream);
         stream

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,4 +6,6 @@ pub enum Error {
     Io(#[error(source)] std::io::Error),
     #[error(display = "_0")]
     Dns(#[error(source)] dns_parser::Error),
+    #[error(display = "_0")]
+    TimeoutError(#[error(source)] async_std::future::TimeoutError),
 }


### PR DESCRIPTION
Currently this crate only runs on the tokio runtime. This means it's impossible to use this crate with https://gtk-rs.org/, because gtk-rs doesn't use tokio.

Switching to async-std will improve interoperability with other executors. It will even work with tokio, so it's not a breaking change.