### PR TITLE
Switch to async-std (re-implement #20)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ err-derive = "0.2.1"
 futures-core = "0.3.1"
 futures-util = "0.3.1"
 async-stream = "0.2.0"
-tokio = { version = "0.2.4", features = ["time", "udp", "stream"] }
+async-std = { version = "1.7.0", features = ["unstable"] }
 
 [dev-dependencies]
-tokio = { version = "0.2.4", features = ["macros", "rt-core"] }
+async-std = { version = "1.7.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdns"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Dylan McKay <me@dylanmckay.io>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,16 @@ use futures_util::{pin_mut, stream::StreamExt};
 use mdns::{Error, Record, RecordKind};
 use std::{net::IpAddr, time::Duration};
 
-
 const SERVICE_NAME: &'static str = "_googlecast._tcp.local";
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     // Iterate through responses from each Cast device, asking for new devices every 15s
     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();
     pin_mut!(stream);
 
     while let Some(Ok(response)) = stream.next().await {
-        let addr = response.records()
-                           .filter_map(self::to_ip_addr)
-                           .next();
+        let addr = response.records().filter_map(self::to_ip_addr).next();
 
         if let Some(addr) = addr {
             println!("found cast device at {}", addr);

--- a/examples/chromecast_discovery.rs
+++ b/examples/chromecast_discovery.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 const SERVICE_NAME: &'static str = "_googlecast._tcp.local";
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();
     pin_mut!(stream);

--- a/examples/http_discovery.rs
+++ b/examples/http_discovery.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 const SERVICE_NAME: &'static str = "_http._tcp.local";
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();
     pin_mut!(stream);

--- a/examples/resolve_hosts.rs
+++ b/examples/resolve_hosts.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 const SERVICE_NAME: &'static str = "_http._tcp.local";
 const HOSTS: [&'static str; 2] = ["server1._http._tcp.local", "server2._http._tcp.local"];
 
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Error> {
     let responses = mdns::resolve::multiple(SERVICE_NAME, &HOSTS, Duration::from_secs(15)).await?;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,4 +6,6 @@ pub enum Error {
     Io(#[error(source)] std::io::Error),
     #[error(display = "_0")]
     Dns(#[error(source)] dns_parser::Error),
+    #[error(display = "_0")]
+    TimeoutError(#[error(source)] async_std::future::TimeoutError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! /// Every Chromecast will respond to the service name in this example.
 //! const SERVICE_NAME: &'static str = "_googlecast._tcp.local";
 //!
-//! #[tokio::main]
+//! #[async_std::main]
 //! async fn main() -> Result<(), Error> {
 //!     // Iterate through responses from each Cast device, asking for new devices every 15s
 //!     let stream = mdns::discover::all(SERVICE_NAME, Duration::from_secs(15))?.listen();


### PR DESCRIPTION
This allows this library to run in other runtimes (not only tokio).

This is PR re-implementation #20 with fixes

Bump minor version, 1.1.0 -> 1.2.0

Closes #21
