### PR TITLE
Explicitly set IP_MULTICAST_IF to ensure that queries are sent on specified NIC

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -7,6 +7,8 @@ use futures_core::Stream;
 use std::sync::Arc;
 use async_std::net::UdpSocket;
 
+use net2::UdpSocketExt;
+
 #[cfg(not(target_os = "windows"))]
 use net2::unix::UnixUdpBuilderExt;
 use std::net::SocketAddr;
@@ -23,6 +25,7 @@ pub fn mdns_interface(
 
     socket.set_multicast_loop_v4(false)?;
     socket.join_multicast_v4(&MULTICAST_ADDR, &interface_addr)?;
+    socket.set_multicast_if_v4(&interface_addr)?;
 
     let socket = Arc::new(UdpSocket::from(socket));
 


### PR DESCRIPTION
When using a multihomed environment, the library allows the user to specified a NIC to search for a particular service; however without setting IP_MULTICAST_IF, the OS is free to send the query on an interface of its choosing. This change forces the send to occur on the user specified interface. This change works also when using INADDR_ANY.