### PR TITLE
Fix log build error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ net2 = "0.2"
 err-derive = "0.2.1"
 futures-core = "0.3.1"
 futures-util = "0.3.1"
-log = "0.4"
+log = "0.4.16"
 async-stream = "0.2.0"
 async-std = { version = "1.6.2", features = ["unstable", "attributes"] }


### PR DESCRIPTION
There is a build error for some machines using log version 0.4.14. It is fixed in log 0.4.16. Refer to https://github.com/rust-lang/log/issues/500 for details.