### PR TITLE
Add loopback optionality

### DIFF
--- a/src/discover.rs
+++ b/src/discover.rs
@@ -22,11 +22,11 @@
 //! }
 //! ```
 
-use crate::{mDNSListener, mdns::mdns_interface_with_loopback, Error, Response};
+use crate::{mDNSListener, Error, Response};
 
 use std::time::Duration;
 
-use crate::mdns::{mDNSSender, mdns_interface};
+use crate::mdns::{mDNSSender, mdns_interface, mdns_interface_with_loopback};
 use futures_core::Stream;
 use futures_util::{future::ready, stream::select, StreamExt};
 use std::net::Ipv4Addr;


### PR DESCRIPTION
Currently the code base assumes the user does _not_ want loopback functionality. This is a reasonable default, but can be a blocker in cases where loopback is important. This PR maintains the default but adds additional `*_with_loopback` methods.